### PR TITLE
Use static, dependabot-parseable forms in gemspec

### DIFF
--- a/hmap.gemspec
+++ b/hmap.gemspec
@@ -1,12 +1,14 @@
+require_relative "lib/hmap/version"
+
 Gem::Specification.new do |s|
   s.authors     = ["Daniel Pepper"]
   s.description = "Improved Hash mapping functions"
   s.files       = `git ls-files * ":!:spec"`.split("\n")
   s.homepage    = "https://github.com/dpep/rb_hmap"
   s.license     = "MIT"
-  s.name        = File.basename(__FILE__, ".gemspec")
+  s.name        = "hmap"
   s.summary     = "Hmap"
-  s.version     = "1.0.1"
+  s.version     = Hmap::VERSION
 
   s.required_ruby_version = ">= 3"
 

--- a/lib/hmap/version.rb
+++ b/lib/hmap/version.rb
@@ -1,3 +1,3 @@
 module Hmap
-  VERSION = Gem.loaded_specs["hmap"].version.to_s
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
## Summary

Dependabot's gemspec parser is **static** — it doesn't eval Ruby, it reads the AST and only handles literal `s.name = "string"` and `s.version = SomeConst::VERSION`. The dynamic forms we had defeated that.

When dependabot can't extract the version statically it falls back to `0.0.1` and writes that into `Gemfile.lock`, which then fails CI in frozen mode (gem version mismatch). See dpep/meddleware_rb#18 for the original diagnosis.

This PR switches to the canonical Bundler-scaffold shape:

```ruby
s.name    = "hmap"
s.version = Hmap::VERSION
```


`lib/hmap/version.rb` switches to a literal `VERSION = "1.0.1"` (it was using the circular `Gem.loaded_specs["hmap"].version.to_s` lookup, which can't work once the gemspec references the constant directly during load).

## Test plan

- [x] `Bundler.load_gemspec("hmap.gemspec")` parses statically to name=`hmap`, version=`1.0.1`
- [x] `bundle install` runs cleanly

## Pattern reference

- dpep/meddleware_rb#18 (diagnosis)
- dpep/amenable_rb#7 (template)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
